### PR TITLE
Fix storage.js writable store creation

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -29,7 +29,7 @@ export function fileDownloadStore(path, opts) {
 
   // Timout
   // Runs of first subscription
-    const start = async() => {
+    const start = () => {
 
       const requests = [url && ref.getDownloadURL(), meta && ref.getMetadata()];
 


### PR DESCRIPTION
Fixes https://github.com/codediodeio/sveltefire/issues/16

The start function passed to a writable store must return a callable stop function that is called after the last subscriber unsubscribes. It can also return nothing which counts as noop. Here, the start function was async, so it returned a promise. Svelte then tried to call that promise as a function which caused an error.

Relevant svelte docs section: https://svelte.dev/docs#writable

See also https://github.com/sveltejs/svelte/issues/4048