### PR TITLE
Fix Markdown syntax typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Slot props can be renamed:
     {post.content}
     {postRef.path}
 </Doc>
+```
 
 All Firestore components can also handle loading states:
   


### PR DESCRIPTION
There was a <code>```</code> missing, so I added it.