### PR TITLE
showing a loading Spinner on first page load

### DIFF
--- a/src/lib/components/AuthLoading.svelte
+++ b/src/lib/components/AuthLoading.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { userStore } from "../stores/auth.js";
+</script>
+
+{#if $user === undefined}
+  <slot {auth}>Loading...</slot>
+{/if}

--- a/src/lib/components/AuthLoading.svelte
+++ b/src/lib/components/AuthLoading.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+  import { getFirebaseContext } from "../stores/sdk.js";
   import { userStore } from "../stores/auth.js";
+  const auth = getFirebaseContext().auth!;
+  const user = userStore(auth);
 </script>
 
 {#if $user === undefined}

--- a/src/lib/components/SignedOut.svelte
+++ b/src/lib/components/SignedOut.svelte
@@ -12,6 +12,6 @@
 
   </script>
   
-  {#if !$user}
+  {#if $user === null}
     <slot {auth} />
   {/if}

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -1,18 +1,20 @@
-import { writable } from "svelte/store";
-import { getFirebaseContext } from "./sdk.js";
-import { onAuthStateChanged, type Auth } from "firebase/auth";
+import { readable, writable } from "svelte/store";
+import { onAuthStateChanged, type Auth, type User } from "firebase/auth";
 
 /**
  * @param  {Auth} auth firebase auth instance
  * @param  {any} startWith optional default data. Useful for server-side cookie-based auth
  * @returns a store with the current firebase user
+ * user != null -> signed in
+ * user == null -> signed out
+ * user == undefined -> still loading auth status on initial page load -> show loading spinner or sth else to prevent a normally signed in user from seeing content as a signed out user for a second
  */
-export function userStore(auth: Auth, startWith = null) {
+export function userStore(auth: Auth, startWith = undefined) {
   let unsubscribe: () => void;
 
   // Fallback for SSR
   if (!globalThis.window) {
-    const { subscribe } = writable(startWith);
+    const { subscribe } = readable(startWith);
     return {
       subscribe,
     };
@@ -23,19 +25,19 @@ export function userStore(auth: Auth, startWith = null) {
     console.warn(
       "Firebase Auth is not initialized. Are you missing FirebaseApp as a parent component?"
     );
-    const { subscribe } = writable(null);
+    const { subscribe } = readable(undefined);
     return {
       subscribe,
     };
   }
 
-  const { subscribe } = writable(auth?.currentUser ?? null, (set) => {
-    unsubscribe = onAuthStateChanged(auth, (user) => {
-      set(user);
-    });
-
-    return () => unsubscribe();
-  });
+  const { subscribe } = readable<User | null | undefined>(
+    auth.currentUser ?? undefined,
+    (set) => {
+      const unsubscribe = onAuthStateChanged(auth, set);
+      return () => unsubscribe();
+    }
+  );
 
   return {
     subscribe,

--- a/src/routes/auth-test/+page.svelte
+++ b/src/routes/auth-test/+page.svelte
@@ -2,7 +2,7 @@
   import SignedIn from '$lib/components/SignedIn.svelte';
   import SignedOut from '$lib/components/SignedOut.svelte';
   import { signInAnonymously } from "firebase/auth";
-
+  import AuthLoading from "$lib/components/AuthLoading.svelte";
 
 </script>
 
@@ -18,3 +18,8 @@
      <h2>Signed Out</h2>
     <button on:click={() => signInAnonymously(auth)}>Sign In</button>
 </SignedOut>
+
+<AuthLoading>
+    <h2>Checking Auth</h2>
+    <p>Loading...</p>
+</AuthLoading>


### PR DESCRIPTION
Hey guys,

I love svelte and firebase ❤️ 🔥  So I had to take a look at sveltefire too! Its awesome!

But I face a small issue which I wanna try to solve with this contribution. 
It would be great if you could have a look at it and maybe give me some Feedback.

**Problem:**
So what was my intention? I used the `<SignedIn>...</SignedIn>` and `<SignedOut></SignedOut>` components. However, I ran into the problem that when I was logged in and reloaded the page (so the `onAuthStateChanged()` method is triggered again), the auth user is momentarily `null`. This caused me to **very briefly** see the content of a logged out user. But this disappeared after a few milli seconds, because I am logged in and the auth status was updated. **So I had a short "flashing".** This leads to a bad user experience in my opinion. Especially with a more complex UI.
short example: 
https://github.com/codediodeio/sveltefire/assets/61154357/bdbc8fc6-7316-4de6-864b-959136789b44


**Solution:**
For me it would be a better solution to show optionally a loading spinner or something to indicate that the user auth status is still loading... As an example I just display "Loading..." in this PR.
This issue was that the user within the store was either **null** or **not null**. 
Since the user is always `null` at the initial page load and we don't know exactly when the auth status was really checked, I had the idea to set the initial value to `undefined`. So you can show a loading spinner until the auth status is no longer `undefined`. 
short example with my solution (with a dummy loading indicator):
https://github.com/codediodeio/sveltefire/assets/61154357/bc665057-a787-4da5-b994-ba34fa016e01

// Optionally you can omit the `AuthLoading`. In that case you see directly the right content which takes a few milli seconds. But then still without the flashing. So this results also in a better User Experience for me personally. 

_I think we won't have any issues with server site rendering. We can still set the `startsWith` parameter. If this is not set, you would see the information as a logged out user through the SSR anyway, which is negligible for SEO backgrounds._


So there are 3 status:
1. user != null -> signed in
2. user == null -> signed out
3. user == undefined -> still loading auth status on initial page load

In my eyes this is a very useful feature, which leads to a better user experience.

What is your opinion? ❤️ 