### PR TITLE
Make Firebase Service Props Optional

### DIFF
--- a/src/lib/components/FirebaseApp.svelte
+++ b/src/lib/components/FirebaseApp.svelte
@@ -4,11 +4,11 @@
   import type { Firestore } from "firebase/firestore";
   import type { FirebaseStorage } from "firebase/storage";
 
-  export let firestore: Firestore;
-  export let auth: Auth;
-  export let storage: FirebaseStorage;
+  export let auth: Auth | undefined = undefined;
+  export let firestore: Firestore | undefined = undefined;
+  export let storage: FirebaseStorage | undefined = undefined;
 
-  setFirebaseContext({ firestore, auth, storage });
+  setFirebaseContext({ auth, firestore, storage });
 </script>
 
 <slot />


### PR DESCRIPTION
This PR addresses the concern raised in issue #128. Currently, users are required to provide all Firebase service props (auth, firestore, storage) when using the `FirebaseApp` component, even if they only intend to use one of the services.

To enhance flexibility and usability, this PR makes the Firebase service props optional. Now, users can choose to provide only the services they need, ensuring a more streamlined and versatile experience.